### PR TITLE
Increase fastcgi timeout to prevent error on initial installation

### DIFF
--- a/config/nginx/conf.d/default.conf
+++ b/config/nginx/conf.d/default.conf
@@ -11,6 +11,7 @@ server {
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass php:9000;
         fastcgi_index index.php;
+        fastcgi_read_timeout 600s;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;


### PR DESCRIPTION
Default value (60s) is not long enough for the database migration to finish so the installation fails.